### PR TITLE
  [command] Add JWT authentication system with GraphQL integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,12 +987,14 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "axum",
+ "axum-extra",
  "chrono",
  "command-domain",
  "command-interface-adaptor-if",
  "command-processor",
  "downcast-rs",
  "event-store-adapter-rs",
+ "jsonwebtoken",
  "log",
  "once_cell",
  "serde",
@@ -1441,8 +1466,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1544,6 +1571,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.2.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -2007,6 +2058,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lambda_http"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2459,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3036,6 +3122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0.98"
 axum = "0.8"
+axum-extra = { version = "0.10.1", features = ["typed-header"] }
 async-graphql = "7.0.17"
 async-graphql-axum = "7.0.17"
 async-trait = "0.1.88"
@@ -25,6 +26,7 @@ downcast-rs = "2.0.1"
 env_logger = "0.11.3"
 hyper = { version = "1.6.0", features = ["full"] }
 itertools = "0.14.0"
+jsonwebtoken = "9.3.1"
 log = "0.4.27"
 once_cell = "1.21.3"
 openssl = { version = "0.10.64", features = ["vendored"] }

--- a/modules/command/interface-adaptor/Cargo.toml
+++ b/modules/command/interface-adaptor/Cargo.toml
@@ -14,6 +14,7 @@ command-interface-adaptor-if = { path = "../interface-adaptor-if" }
 command-processor = { path = "../processor" }
 command-domain = { path = "../domain" }
 downcast-rs = { workspace = true }
+jsonwebtoken = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -24,4 +25,5 @@ event-store-adapter-rs = { workspace = true }
 async-graphql = { workspace = true, features = ["chrono"] }
 
 axum = { workspace = true }
+axum-extra = { workspace = true, features = ["typed-header"] }
 async-graphql-axum = { workspace = true }

--- a/modules/command/interface-adaptor/src/controllers.rs
+++ b/modules/command/interface-adaptor/src/controllers.rs
@@ -9,6 +9,8 @@ use crate::gateways::project_repository::AwsDynamoDbProjectRepository;
 
 use crate::graphql::{ApiSchema, ES, create_schema};
 
+pub(crate) mod extractor;
+
 pub enum EndpointPaths {
     Root,
     HealthAlive,
@@ -40,8 +42,12 @@ pub async fn ready() -> impl IntoResponse {
 }
 
 /// GraphQLのリクエストを受け付けるエンドポイント。
-async fn graphql_handler(schema: Extension<ApiSchema>, req: GraphQLRequest) -> GraphQLResponse {
-    schema.execute(req.into_inner()).await.into()
+async fn graphql_handler(
+    schema: Extension<ApiSchema>,
+    authorized_user: extractor::AuthorizedUser,
+    req: GraphQLRequest,
+) -> GraphQLResponse {
+    schema.execute(req.into_inner().data(authorized_user)).await.into()
 }
 
 /// GraphQL IDEのためのエンドポイント。

--- a/modules/command/interface-adaptor/src/controllers/extractor.rs
+++ b/modules/command/interface-adaptor/src/controllers/extractor.rs
@@ -1,0 +1,113 @@
+use std::str::FromStr;
+
+use axum::RequestPartsExt;
+use axum::extract::FromRequestParts;
+use axum::http::{HeaderName, StatusCode, request::Parts};
+use axum_extra::{TypedHeader, headers::Header};
+use jsonwebtoken::{DecodingKey, TokenData, Validation, decode};
+use serde::{Deserialize, Serialize};
+
+use command_domain::user::UserId;
+
+pub struct XCustomeAuthorization(pub String);
+
+impl Header for XCustomeAuthorization {
+    fn name() -> &'static HeaderName {
+        static NAME: HeaderName = HeaderName::from_static("x-custom-authorization");
+        &NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, axum_extra::headers::Error>
+    where
+        I: Iterator<Item = &'i axum::http::HeaderValue>,
+    {
+        values
+            .next()
+            .and_then(|v| v.to_str().ok())
+            .map(|s| XCustomeAuthorization(s.to_string()))
+            .ok_or_else(axum_extra::headers::Error::invalid)
+    }
+
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: Extend<axum::http::HeaderValue>,
+    {
+        if let Ok(value) = axum::http::HeaderValue::from_str(&self.0) {
+            values.extend(std::iter::once(value));
+        }
+    }
+}
+
+// 仮実装
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: usize,
+}
+
+#[derive(Clone)]
+pub struct AuthorizedUser {
+    pub user_id: UserId,
+}
+
+impl<S> FromRequestParts<S> for AuthorizedUser
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, String);
+
+    // handler メソッドの引数に AuthorizedUser を追加したときはこのメソッドが呼ばれる
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let TypedHeader(XCustomeAuthorization(token)) =
+            parts.extract::<TypedHeader<XCustomeAuthorization>>().await.map_err(|_| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "Missing authorization header".into(),
+                )
+            })?;
+
+        let token_data = validate_bearer_token(&token)?;
+
+        let user_id = validate_user_id(&token_data.claims.sub)?;
+
+        Ok(Self { user_id })
+    }
+}
+
+// 仮実装
+// 認証サービスを用いて検証するようにしたい
+fn validate_bearer_token(token: &str) -> Result<TokenData<Claims>, (StatusCode, String)> {
+    decode::<Claims>(
+        token,
+        &DecodingKey::from_secret("test-key".as_ref()),
+        &Validation::default(),
+    )
+    .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token".into()))
+}
+
+fn validate_user_id(value: &str) -> Result<UserId, (StatusCode, String)> {
+    UserId::from_str(value).map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_bearer_token() {
+        let claims = Claims {
+            sub: UserId::new().to_string(),
+            exp: (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize,
+        };
+
+        let token = jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret("test-key".as_ref()),
+        )
+        .unwrap();
+
+        let result = validate_bearer_token(token.as_str());
+        assert!(result.is_ok());
+    }
+}

--- a/modules/command/interface-adaptor/src/graphql/inputs.rs
+++ b/modules/command/interface-adaptor/src/graphql/inputs.rs
@@ -3,13 +3,11 @@ use async_graphql::InputObject;
 #[derive(Debug, Clone, InputObject)]
 pub struct CreateProjectInput {
     pub name: String,
-    pub executor_id: String,
 }
 
 #[derive(Debug, Clone, InputObject)]
 pub struct DeleteProjectInput {
     pub project_id: String,
-    pub executor_id: String,
 }
 
 #[derive(Debug, Clone, InputObject)]
@@ -17,19 +15,16 @@ pub struct AddMemberInput {
     pub project_id: String,
     pub user_id: String,
     pub role: String,
-    pub executor_id: String,
 }
 
 #[derive(Debug, Clone, InputObject)]
 pub struct RemoveMemberInput {
     pub project_id: String,
     pub user_id: String,
-    pub executor_id: String,
 }
 
 #[derive(Debug, Clone, InputObject)]
 pub struct RenameProjectInput {
     pub project_id: String,
     pub new_name: String,
-    pub executor_id: String,
 }


### PR DESCRIPTION
  - Implement JWT authentication using x-custom-authorization header
  - Add AuthorizedUser extractor to extract authenticated user from requests
  - Remove executor_id fields from GraphQL inputs and use authenticated user
  - Add access log middleware to log request headers
  - Add jsonwebtoken and axum-extra dependencies